### PR TITLE
Use RUSTC variable in makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 bin
 lib
 build
+config.mk

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 .PHONY: lib all examples test clean
 
-LIBNAME := $(shell rustc --crate-file-name src/toml/lib.rs)
+-include ./config.mk
+
+RUSTC ?= rustc
+
+LIBNAME := $(shell $(RUSTC) --crate-file-name src/toml/lib.rs)
 
 all: lib examples test
 
@@ -8,24 +12,24 @@ lib: lib/$(LIBNAME)
 
 lib/$(LIBNAME): src/toml/lib.rs
 	@mkdir -p lib
-	rustc -O --out-dir lib $<
+	$(RUSTC) -O --out-dir lib $<
 
 test: bin/testsuite
 	./bin/testsuite ./tests
 
 bin/testsuite: src/testsuite/main.rs lib/$(LIBNAME)
 	@mkdir -p bin
-	rustc -O -o bin/testsuite -L lib $<
+	$(RUSTC) -O -o bin/testsuite -L lib $<
 
 examples: bin/simple bin/decoder
 
 bin/simple: src/examples/simple/main.rs lib/$(LIBNAME)
 	@mkdir -p bin
-	rustc -o bin/simple -L lib $<
+	$(RUSTC) -o bin/simple -L lib $<
 
 bin/decoder: src/examples/decoder/main.rs lib/$(LIBNAME)
 	@mkdir -p bin
-	rustc -o bin/decoder -L lib $<
+	$(RUSTC) -o bin/decoder -L lib $<
 
 clean:
 	-$(RM) -r bin

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ A [TOML][toml-home] configuration file parser for [Rust][rust-home].
 [toml-home]: https://github.com/mojombo/toml
 [rust-home]: http://www.rust-lang.org
 
+To build (using your system's ```rustc```):
+
+    make
+
+To use another rustc create a file called ```config.mk``` with:
+
+    RUSTC ?= /path/to/rustc
+
+
 ## Quickstart
 
 Given the following TOML configuration file:


### PR DESCRIPTION
I've added a `RUSTC` variable to the makefile. People that want to use another `rustc` than the installed one can create a `config.mk` which contains the path to the `rustc` executable.

Cheers
